### PR TITLE
refactor(redlock): apply interface 

### DIFF
--- a/redlock/redlock.go
+++ b/redlock/redlock.go
@@ -53,8 +53,15 @@ type RedLock struct {
 	client []*RedClient
 }
 
+type RedLocker interface {
+	SetLock(ctx context.Context, key string, value string, ttl int) (float64, error)
+	UnSetLock(ctx context.Context, key string, value string) (float64, error)
+	GetLockTtl(ctx context.Context, key string, value string) (int64, error)
+	IsLocked(ctx context.Context, key string) bool
+}
+
 // NewRedisLock returns a RedisLock.
-func NewRedisLock(ctx context.Context, options ...*red.Options) *RedLock {
+func NewRedisLock(ctx context.Context, options ...*red.Options) RedLocker {
 	var clients []*RedClient
 	for _, opt := range options {
 		client := red.NewClient(opt)

--- a/redlock/redlock_test.go
+++ b/redlock/redlock_test.go
@@ -3,8 +3,9 @@ package redlock
 import (
 	"context"
 	"fmt"
-	red "github.com/go-redis/redis/v8"
 	"testing"
+
+	red "github.com/go-redis/redis/v8"
 )
 
 func CommonClient() []*RedClient {
@@ -48,7 +49,11 @@ func TestNewRedisLock(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewRedisLock(tt.args.ctx, tt.args.options...)
-			for _, client := range got.client {
+			gotOut, ok := got.(*RedLock)
+			if !ok {
+				t.Fatalf("new redis lock was not a redlock instance")
+			}
+			for _, client := range gotOut.client {
 				err := client.cli.Ping(ctx).Err()
 				if err != nil {
 					t.Fatalf("redis connect error")


### PR DESCRIPTION
## Context 

Users of this library may want to mock `RedLock` when creating unit tests in their own application logic. I contemplated just creating the interface in my own project but I think it would be more useful for the community if the library just ships one itself. This should also provide a little more flexibily in the future as the underlying `RedLock` struct is abstracted away from users and you can switch out the implementation if ever needed. 

## Changes

- Introduce Public Interface `RedLocker` and swap out return for `NewRedisLock`
- Update `TestNewRedisLock` to verify underlying instance